### PR TITLE
#3 Encode search string

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,7 +181,7 @@ function search(nodelay, nextPage) {
 
     var xmlHttp = new XMLHttpRequest();
 
-    var url = 'https://www.googleapis.com/youtube/v3/search?part=snippet&q=' + search_i.value + '&type=video&maxResults=10&key=' + API_KEY;
+    var url = 'https://www.googleapis.com/youtube/v3/search?part=snippet&q=' + encodeURIComponent(search_i.value) + '&type=video&maxResults=10&key=' + API_KEY;
     if (nextPage && nextPageToken)
         url += '&pageToken=' + nextPageToken;
 


### PR DESCRIPTION
Fixes #3 : Searching for text containing characters like # breaking the search entirely until next refresh by encoding search string with `encodeURIComponent`.
